### PR TITLE
12 development lat bins

### DIFF
--- a/R/lat_bins.R
+++ b/R/lat_bins.R
@@ -1,18 +1,27 @@
 #' Generate latitudinal bins
 #'
-#' A function to generate latitudinal bins of a given size. If the desired size of the bins is not compatible
-#' with the entire latitudinal range (90ºS to 90ºN), bin size can be updated to the nearest integer which is
-#' divisible into 180 to fit the entire range.
+#' A function to generate latitudinal bins of a given size. If the desired size
+#' of the bins is not compatible with the entire latitudinal range
+#' (90&deg;S to 90&deg;N ), bin size can be updated to the nearest integer
+#' which is divisible into 180 to fit the entire range.
 #'
-#' @param size \code{numeric}. A single numeric value of more than 0, and less than or equal to 90.
-#' @param fit \code{logical}. Should bin size be checked to ensure that the entire latitudinal
-#' range is covered (90ºS to 90ºN)? If \code{fit = TRUE}, bin size is set to the nearest integer
-#' which is divisible into 180 (the entire latitudinal range).
-#' @param assign \code{numeric}. A numeric vector of latitudes (or palaeolatitudes) to use to assign to bins of
-#' a given size. If assign is specified, a numeric vector is returned of the midpoint latitudes of the specified bins.
-#' @param plot \code{logical}. Should a plot of the latitudinal bins be generated?
-#' @return A \code{dataframe} of latitudinal bins of a given size or a list with a \code{dataframe} of latitudinal bins
-#' and \code{numeric} vector of binned latitudes (midpoint latitude of bin) if assign specified.
+#' @param size \code{numeric}. A single numeric value of more than 0, and less
+#' than, or equal to 90.
+#' @param fit \code{logical}. Should bin size be checked to ensure that the
+#' entire latitudinal
+#' range is covered (90&deg;S to 90&deg;N)? If \code{fit = TRUE}, bin size is
+#' set to the nearest integer which is divisible into 180 (the entire
+#' latitudinal range).
+#' @param assign \code{numeric}. A numeric vector of latitudes (or
+#' palaeolatitudes) to use to assign to bins of a given size. If assign is
+#' specified, a numeric vector is returned of the midpoint latitudes of the
+#' specified bins.
+#' @param plot \code{logical}. Should a plot of the latitudinal bins be
+#' generated?
+#' @return A \code{dataframe} of latitudinal bins of a given size, or a list
+#' with a \code{dataframe} of the latitudinal bins,
+#' and a named \code{numeric} vector (bin number) of binned latitudes
+#' (midpoint latitude of bin) if assign specified.
 #' @importFrom graphics polygon abline title
 #' @section Developer:
 #' Lewis A. Jones
@@ -28,26 +37,26 @@
 #' #Assign bins based on given latitudes
 #' lat_bins(assign = c(-20, 45, 11, 67))
 #' @export
-lat_bins <- function(size = 10, fit = FALSE, assign = NULL, plot = TRUE){
+lat_bins <- function(size = 10, fit = FALSE, assign = NULL, plot = FALSE){
   #error handling
   if (is.numeric(size) == FALSE) {
-    stop("Size should be a numeric")
+    stop("`size` should be a numeric")
   }
 
   if (size > 90 | size < 0) {
-    stop("Size should be more than 0 and less or equal to 90")
+    stop("`size` should be more than 0 and less than or equal to 90")
   }
 
   if (is.logical(fit) == FALSE) {
-    stop("fit should be logical (TRUE/FALSE)")
+    stop("`fit` should be logical (TRUE/FALSE)")
   }
 
-  if (sum(assign > 90) != 0 | sum(assign < -90) != 0) {
-    stop("Latitude should be more than -90 and less than 90")
+  if (any(assign > 90 | assign < -90)) {
+    stop("Latitudes (`assign`) should be more than -90 and less than 90")
   }
 
   if (is.logical(plot) == FALSE) {
-    stop("plot should be logical (TRUE/FALSE)")
+    stop("`plot` should be logical (TRUE/FALSE)")
   }
 
   #divide latitudinal range by size of bins
@@ -73,8 +82,8 @@ lat_bins <- function(size = 10, fit = FALSE, assign = NULL, plot = TRUE){
   #plot latitudinal bins
   if(plot == TRUE){
     plot(1, type = "n", xlim = c(-180, 180), ylim = c(min(df$min), max(df$max)), xlab = "Longitude (\u00B0)", ylab = "Latitude (\u00B0)")
-    cols <- rep(c("#2166ac", "#b2182b"), nrow(df))
-    for(i in 1:nrow(df)){
+    cols <- rep(c("#2ca25f", "#ccece6"), nrow(df))
+    for(i in seq_len(nrow(df))){
       polygon(x = c(-180, -180, 180, 180),
               y = c(df$min[i], df$max[i], df$max[i], df$min[i]),
               col = cols[i],
@@ -86,17 +95,17 @@ lat_bins <- function(size = 10, fit = FALSE, assign = NULL, plot = TRUE){
   }
 
   if(fit == TRUE){
-    message(paste0("Bin size set to ",size," degrees to fit latitudinal range."))
+    message(paste0(
+      "Bin size set to ", size, " degrees to fit latitudinal range."))
   }
 
   if(!is.null(assign)){
     if(is.numeric(assign)){
-      if(any(assign > 90 | assign < -90)){
-        stop("One or more latitudes is more than or less than 90/-90")
-     }
     tmp <- assign
       for(i in 1:nrow(df)){
         assign[which(tmp <= df$max[i] & tmp >= df$min[i])] <- df$mid[i]
+        names(assign)[which(tmp <= df$max[i] &
+                              tmp >= df$min[i])] <- df$bin[i]
       }
     assign <- list(df, assign)
     names(assign) <- c("Bins", "Assignation")

--- a/R/lat_bins.R
+++ b/R/lat_bins.R
@@ -6,7 +6,7 @@
 #' which is divisible into 180 to fit the entire range.
 #'
 #' @param size \code{numeric}. A single numeric value of more than 0, and less
-#' than, or equal to 90.
+#' than or equal to 90.
 #' @param fit \code{logical}. Should bin size be checked to ensure that the
 #' entire latitudinal
 #' range is covered (90&deg;S to 90&deg;N)? If \code{fit = TRUE}, bin size is

--- a/R/lat_bins.R
+++ b/R/lat_bins.R
@@ -3,7 +3,9 @@
 #' A function to generate latitudinal bins of a given size. If the desired size
 #' of the bins is not compatible with the entire latitudinal range
 #' (90&deg;S to 90&deg;N ), bin size can be updated to the nearest integer
-#' which is divisible into 180 to fit the entire range.
+#' which is divisible into 180 to fit the entire range. This function also
+#' allows the user to easily assign occurrence data to latitudinal bins via
+#' the assign argument.
 #'
 #' @param size \code{numeric}. A single numeric value of more than 0, and less
 #' than or equal to 90.

--- a/R/time_bins.R
+++ b/R/time_bins.R
@@ -36,7 +36,7 @@
 #' @importFrom stats sd
 #'
 #' @return A \code{dataframe} of time bins for the specified intervals or a
-#' list with a \code{dataframe} of time bins and \code{numeric} a named
+#' list with a \code{dataframe} of time bins and a named \code{numeric}
 #' vector (bin number) of binned age estimates (midpoint of specified bins) if
 #' assign is specified.
 #'

--- a/man/lat_bins.Rd
+++ b/man/lat_bins.Rd
@@ -4,28 +4,37 @@
 \alias{lat_bins}
 \title{Generate latitudinal bins}
 \usage{
-lat_bins(size = 10, fit = FALSE, assign = NULL, plot = TRUE)
+lat_bins(size = 10, fit = FALSE, assign = NULL, plot = FALSE)
 }
 \arguments{
-\item{size}{\code{numeric}. A single numeric value of more than 0, and less than or equal to 90.}
+\item{size}{\code{numeric}. A single numeric value of more than 0, and less
+than, or equal to 90.}
 
-\item{fit}{\code{logical}. Should bin size be checked to ensure that the entire latitudinal
-range is covered (90ºS to 90ºN)? If \code{fit = TRUE}, bin size is set to the nearest integer
-which is divisible into 180 (the entire latitudinal range).}
+\item{fit}{\code{logical}. Should bin size be checked to ensure that the
+entire latitudinal
+range is covered (90°S to 90°N)? If \code{fit = TRUE}, bin size is
+set to the nearest integer which is divisible into 180 (the entire
+latitudinal range).}
 
-\item{assign}{\code{numeric}. A numeric vector of latitudes (or palaeolatitudes) to use to assign to bins of
-a given size. If assign is specified, a numeric vector is returned of the midpoint latitudes of the specified bins.}
+\item{assign}{\code{numeric}. A numeric vector of latitudes (or
+palaeolatitudes) to use to assign to bins of a given size. If assign is
+specified, a numeric vector is returned of the midpoint latitudes of the
+specified bins.}
 
-\item{plot}{\code{logical}. Should a plot of the latitudinal bins be generated?}
+\item{plot}{\code{logical}. Should a plot of the latitudinal bins be
+generated?}
 }
 \value{
-A \code{dataframe} of latitudinal bins of a given size or a list with a \code{dataframe} of latitudinal bins
-and \code{numeric} vector of binned latitudes (midpoint latitude of bin) if assign specified.
+A \code{dataframe} of latitudinal bins of a given size, or a list
+with a \code{dataframe} of the latitudinal bins,
+and a named \code{numeric} vector (bin number) of binned latitudes
+(midpoint latitude of bin) if assign specified.
 }
 \description{
-A function to generate latitudinal bins of a given size. If the desired size of the bins is not compatible
-with the entire latitudinal range (90ºS to 90ºN), bin size can be updated to the nearest integer which is
-divisible into 180 to fit the entire range.
+A function to generate latitudinal bins of a given size. If the desired size
+of the bins is not compatible with the entire latitudinal range
+(90°S to 90°N ), bin size can be updated to the nearest integer
+which is divisible into 180 to fit the entire range.
 }
 \section{Developer}{
 

--- a/man/lat_bins.Rd
+++ b/man/lat_bins.Rd
@@ -34,7 +34,9 @@ and a named \code{numeric} vector (bin number) of binned latitudes
 A function to generate latitudinal bins of a given size. If the desired size
 of the bins is not compatible with the entire latitudinal range
 (90°S to 90°N ), bin size can be updated to the nearest integer
-which is divisible into 180 to fit the entire range.
+which is divisible into 180 to fit the entire range. This function also
+allows the user to easily assign occurrence data to latitudinal bins via
+the assign argument.
 }
 \section{Developer}{
 

--- a/man/lat_bins.Rd
+++ b/man/lat_bins.Rd
@@ -8,7 +8,7 @@ lat_bins(size = 10, fit = FALSE, assign = NULL, plot = FALSE)
 }
 \arguments{
 \item{size}{\code{numeric}. A single numeric value of more than 0, and less
-than, or equal to 90.}
+than or equal to 90.}
 
 \item{fit}{\code{logical}. Should bin size be checked to ensure that the
 entire latitudinal

--- a/man/time_bins.Rd
+++ b/man/time_bins.Rd
@@ -43,7 +43,7 @@ be used "GTS2020" or "GTS2012". "GTS2020" is the default.}
 }
 \value{
 A \code{dataframe} of time bins for the specified intervals or a
-list with a \code{dataframe} of time bins and \code{numeric} a named
+list with a \code{dataframe} of time bins and a named \code{numeric}
 vector (bin number) of binned age estimates (midpoint of specified bins) if
 assign is specified.
 }

--- a/tests/testthat/test-lat_bins.R
+++ b/tests/testthat/test-lat_bins.R
@@ -1,0 +1,19 @@
+test_that("lat_bins() works", {
+
+  #expect equal
+  expect_equal(nrow(lat_bins()), 18)
+  expect_equal(nrow(lat_bins(size = 13)), 13)
+  expect_equal(nrow(lat_bins(size = 13, fit = TRUE)), 15)
+  expect_equal(nrow(lat_bins(size = 13, fit = TRUE, plot = TRUE)), 15)
+
+  #expect true
+  expect_true(is.list(lat_bins(assign = c(-20, 45, 11, 67))))
+
+  #expect error
+  expect_error(lat_bins(assign = c(-100)))
+  expect_error(lat_bins(size = 100))
+  expect_error(lat_bins(fit = 1))
+  expect_error(lat_bins(size = "10"))
+  expect_error(lat_bins(plot = "TRUE"))
+
+})


### PR DESCRIPTION
# lat_bins()

## Description

A function to generate latitudinal bins of a given size. If the desired size of the bins is not compatible with the entire latitudinal range (90°S to 90°N ), bin size can be updated to the nearest integer which is divisible into 180 to fit the entire range. This function also allows the user to easily assign occurrence data to latitudinal bins through the assign argument.

## Motivation and Context

Palaeobiologists and macroecologists are often required to bin their data into latitudinal bins (e.g. to study the latitudinal biodiversity gradient). This function allows users to rapidly generate latitudinal bins and assign their data to those bins. 

![image](https://user-images.githubusercontent.com/41071747/179574647-b28d9de1-1f6d-4ef0-a014-288b963feb88.png)
