### PR TITLE
Fix look_up()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ Minor bug fixes
 * Fixed tests when suggested packages were not installed (#64)
 * Removed dependence of tests on divDyn and deeptime
 * Fixed tax_range_time example (#60)
+* Fixed look_up issue when handling pre-Cambrian occurrences.
 
 Added package-level documentation function
 

--- a/R/look_up.R
+++ b/R/look_up.R
@@ -338,7 +338,7 @@ look_up <- function(occdf, early_interval = "early_interval",
     # remove pre-Cambrian intervals as there are no stages defined
     pre_camb <- which(assigned_min_ma_gts >=
                         gts$max_ma[which(gts$interval_name == "Fortunian")])
-    if(length(pre_camb) >= 1) {
+    if (length(pre_camb) >= 1) {
       assigned_min_ma_gts <- assigned_min_ma_gts[-pre_camb]
       assign_gts2 <- assign_gts2[-pre_camb]
     }

--- a/R/look_up.R
+++ b/R/look_up.R
@@ -308,8 +308,9 @@ look_up <- function(occdf, early_interval = "early_interval",
     }, FUN.VALUE = numeric(1))
 
     # remove pre-Cambrian intervals as there are no stages defined
-    pre_camb <- which(assigned_max_ma_gts > gts$max_ma[which(gts$interval_name=="Fortunian")])
-    if(length(pre_camb) >=1) {
+    pre_camb <- which(assigned_max_ma_gts >
+                        gts$max_ma[which(gts$interval_name == "Fortunian")])
+    if (length(pre_camb) >= 1) {
       assigned_max_ma_gts <- assigned_max_ma_gts[-pre_camb]
       assign_gts1 <- assign_gts1[-pre_camb]
     }
@@ -335,8 +336,9 @@ look_up <- function(occdf, early_interval = "early_interval",
     }, FUN.VALUE = numeric(1))
 
     # remove pre-Cambrian intervals as there are no stages defined
-    pre_camb <- which(assigned_min_ma_gts >= gts$max_ma[which(gts$interval_name=="Fortunian")])
-    if(length(pre_camb) >=1) {
+    pre_camb <- which(assigned_min_ma_gts >=
+                        gts$max_ma[which(gts$interval_name == "Fortunian")])
+    if(length(pre_camb) >= 1) {
       assigned_min_ma_gts <- assigned_min_ma_gts[-pre_camb]
       assign_gts2 <- assign_gts2[-pre_camb]
     }

--- a/R/look_up.R
+++ b/R/look_up.R
@@ -306,13 +306,20 @@ look_up <- function(occdf, early_interval = "early_interval",
     assigned_max_ma_gts <- vapply(assign_gts1, function(x) {
       gts$max_ma[x == gts$interval_name]
     }, FUN.VALUE = numeric(1))
-    # stage
+
+    # remove pre-Cambrian intervals as there are no stages defined
+    pre_camb <- which(assigned_max_ma_gts > gts$max_ma[which(gts$interval_name=="Fortunian")])
+    if(length(pre_camb) >=1) {
+      assigned_max_ma_gts <- assigned_max_ma_gts[-pre_camb]
+      assign_gts1 <- assign_gts1[-pre_camb]
+    }
+
+    # assign early stages to occurrences
     for (i in seq_len(length(assign_gts1))) {
       occdf$early_stage[early == assign_gts1[i] &
                           is.na(occdf$early_stage)] <-
         gts$interval_name[gts$max_ma == assigned_max_ma_gts[i] &
                             gts$rank == "stage"]
-
     }
 
     # late stages
@@ -326,13 +333,21 @@ look_up <- function(occdf, early_interval = "early_interval",
     assigned_min_ma_gts <- vapply(assign_gts2, function(x) {
       gts$min_ma[x == gts$interval_name]
     }, FUN.VALUE = numeric(1))
+
+    # remove pre-Cambrian intervals as there are no stages defined
+    pre_camb <- which(assigned_min_ma_gts >= gts$max_ma[which(gts$interval_name=="Fortunian")])
+    if(length(pre_camb) >=1) {
+      assigned_min_ma_gts <- assigned_min_ma_gts[-pre_camb]
+      assign_gts2 <- assign_gts2[-pre_camb]
+    }
+
+    # assign late stages to occurrences
     for (i in seq_len(length(assign_gts2))) {
       # stage
       occdf$late_stage[late == assign_gts2[i] &
                          is.na(occdf$late_stage)] <-
         gts$interval_name[gts$min_ma == assigned_min_ma_gts[i] &
                             gts$rank == "stage"]
-
     }
 
     # add max_ma and min_ma based on GTS

--- a/tests/testthat/test-look_up.R
+++ b/tests/testthat/test-look_up.R
@@ -27,6 +27,15 @@ test_that("look_up() works", {
                         assign_with_GTS = "GTS2012"))$early_stage[1:2],
                c("Induan", "Asselian"))
 
+  # check that no error is produced when pre-Phanerozoic intervals are included
+  occdf <- reefs
+  occdf$interval[1] <- "Meso-archean"
+  expect_equal((look_up(occdf[which(occdf$interval == "Ediacaran" |
+                                      occdf$interval == "Meso-archean"),],
+                        early_interval = "interval",
+                        late_interval = "interval", assign_with_GTS = "GTS2012",
+                        int_key = FALSE))$early_stage, rep(NA_character_,3))
+
   # check whether unassigned intervals are returned, if required
   occdf <- tetrapods
   vec <- c(NA, " ", "")


### PR DESCRIPTION
# Fix look_up()

## Description
The look_up function tries to look up intervals from the GTS tables and assign stages. This failed for intervals older than the Phanerozoic, as older stages are not defined in the GTS tables, resulting in an error. This error should be fixed with this pull request, and a test has been added.

