### PR TITLE
Address #23: latitudinal binning and variable latitudinal range

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,5 +1,6 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^\.DS_Store$
 ^data-raw$
 ^\.github$
 cran-comments.md
@@ -20,3 +21,4 @@ cran-comments.md
 ^pkgdown$
 ^doc$
 ^Meta$
+.DS_Store

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Language: en-GB
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 Depends: 
     R (>= 4.0)
 Imports:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,10 @@
 # palaeoverse development version
+Updates
+
+* Added package-level documentation function
+* lat_bins now accepts user-defined latitudinal range
+* bin_lat now has functionality for handling boundary occurrences
+
 Minor bug fixes
 
 * Updated palaeorotate reconstruction files to use an hexagonal equal-area grid.
@@ -10,8 +16,6 @@ Minor bug fixes
 * Removed dependence of tests on divDyn and deeptime
 * Fixed tax_range_time example (#60)
 * Fixed look_up issue when handling pre-Cambrian occurrences.
-
-Added package-level documentation function
 
 # palaeoverse 1.0.0
 First full release of the palaeoverse R package.

--- a/R/bin_lat.R
+++ b/R/bin_lat.R
@@ -14,7 +14,7 @@
 #' numerical values. Defaults to "lat".
 #' @param boundary \code{logical}. If \code{TRUE}, occurrences
 #' falling on the boundaries of latitudinal bins will be duplicated and
-#' binded to the dataframe after being assigned to both bins.
+#' assigned to both bins.
 #' If \code{FALSE}, occurrences will be binned into the upper bin
 #' only (i.e. highest row number).
 #'

--- a/R/lat_bins.R
+++ b/R/lat_bins.R
@@ -1,19 +1,22 @@
 #' Generate latitudinal bins
 #'
-#' A function to generate latitudinal bins of a given size. If the desired size
-#' of the bins is not compatible with the entire latitudinal range
-#' (90&deg;S to 90&deg;N ), bin size can be updated to the nearest integer
-#' which is divisible into 180 to fit the entire range.
+#' A function to generate latitudinal bins of a given size for a user-defined
+#' latitudinal range. If the desired size of the bins is not compatible with
+#' the defined latitudinal range, bin size can be updated to the nearest integer
+#' which is divisible into this range.
 #'
 #' @param size \code{numeric}. A single numeric value defining the width of the
 #' latitudinal bins. This value must be more than 0, and less than or equal to
-#' 90.
+#' 90 (defaults to 10).
+#' @param max \code{numeric}. A single numeric value defining the upper limit
+#' of the latitudinal range (defaults to 90).
+#' @param min \code{numeric}. A single numeric value defining the lower limit
+#' of the latitudinal range (defaults to -90).
 #' @param fit \code{logical}. Should bin size be checked to ensure that the
-#' entire latitudinal
-#' range is covered (90&deg;S to 90&deg;N)? If \code{fit = TRUE}, bin size is
-#' set to the nearest integer which is divisible into 180 (the entire
-#' latitudinal range). If \code{fit = FALSE}, and bin size is not divisible
-#' into 180, part of the Northern Hemisphere latitudinal range will be missing.
+#' entire latitudinal range is covered? If \code{fit = TRUE}, bin size is
+#' set to the nearest integer which is divisible by the user-input range.
+#' If \code{fit = FALSE}, and bin size is not divisible into the range, the
+#' upper part of the latitudinal range will be missing.
 #' @param plot \code{logical}. Should a plot of the latitudinal bins be
 #' generated?
 #' @return A \code{dataframe} of latitudinal bins of user-defined size.
@@ -24,16 +27,30 @@
 #' Bethany Allen
 #' @export
 #' @examples
-#' #Generate 20 degrees latitudinal bins
+#' # Generate 20 degrees latitudinal bins
 #' bins <- lat_bins(size = 20)
 #'
-#' #Generate latitudinal bins with closest fit to 13 degrees
+#' # Generate latitudinal bins with closest fit to 13 degrees
 #' bins <- lat_bins(size = 13, fit = TRUE)
 #'
-lat_bins <- function(size = 10, fit = FALSE, plot = FALSE) {
+#' # Generate latitudinal bins for defined latitudinal range
+#' bins <- lat_bins(size = 10, max = 50, min = -50)
+lat_bins <- function(size = 10, max = 90, min = -90, fit = FALSE, plot = FALSE) {
   #error handling
   if (is.numeric(size) == FALSE) {
     stop("`size` should be a numeric")
+  }
+
+  if (max > 90 || max < -90) {
+    stop("`max` should be less than 90 and more than -90")
+  }
+
+  if (min > 90 || min < -90) {
+    stop("`min` should be less than 90 and more than -90")
+  }
+
+  if (min >= max) {
+    stop("`min` should be less than `max`")
   }
 
   if (size > 90 || size < 0) {
@@ -48,19 +65,21 @@ lat_bins <- function(size = 10, fit = FALSE, plot = FALSE) {
     stop("`plot` should be logical (TRUE/FALSE)")
   }
 
-  #divide latitudinal range by size of bins
-  bins <- 180 / size
-  #if fit is set true, generate equal size bins to fit range
+  # Latitudinal range
+  lat_range <- abs(max - min)
+  # Divide latitudinal range by size of bins
+  bins <- lat_range / size
+  # If fit is set true, generate equal size bins to fit range
   if (fit == TRUE) {
     if (is.integer(bins) == FALSE) {
-      int <- 180 / seq(from = 1, to = 90, by = 1)
+      int <- lat_range / seq(from = 1, to = 90, by = 1)
       int <- which(int %% 1 == 0)
       size <- int[which.min(abs(int - size))]
-      bins <- 180 / size
+      bins <- lat_range / size
     }
   }
-  #generate latitudinal bins
-  df <- seq(from = -90, to = 90, by = size)
+  # Generate latitudinal bins for specified range
+  df <- seq(from = min, to = max, by = size)
   min <- df[1:bins]
   max <- df[1:bins] + size
   mid <- (max + min) / 2
@@ -73,7 +92,7 @@ lat_bins <- function(size = 10, fit = FALSE, plot = FALSE) {
     plot(1, type = "n", xlim = c(-180, 180),
          ylim = c(min(df$min), max(df$max)),
          xlab = "Longitude (\u00B0)", ylab = "Latitude (\u00B0)")
-    cols <- rep(c("#feb24c", "#1d91c0"), nrow(df))
+    cols <- rep(c("#01665e", "#80cdc1"), nrow(df))
     for (i in seq_len(nrow(df))){
       polygon(x = c(-180, -180, 180, 180),
               y = c(df$min[i], df$max[i], df$max[i], df$min[i]),

--- a/R/lat_bins.R
+++ b/R/lat_bins.R
@@ -35,7 +35,8 @@
 #'
 #' # Generate latitudinal bins for defined latitudinal range
 #' bins <- lat_bins(size = 10, max = 50, min = -50)
-lat_bins <- function(size = 10, max = 90, min = -90, fit = FALSE, plot = FALSE) {
+lat_bins <- function(size = 10, max = 90, min = -90,
+                     fit = FALSE, plot = FALSE) {
   #error handling
   if (is.numeric(size) == FALSE) {
     stop("`size` should be a numeric")

--- a/man/bin_lat.Rd
+++ b/man/bin_lat.Rd
@@ -4,7 +4,7 @@
 \alias{bin_lat}
 \title{Assign fossil occurrences to latitudinal bins}
 \usage{
-bin_lat(occdf, bins, lat = "lat")
+bin_lat(occdf, bins, lat = "lat", boundary = FALSE)
 }
 \arguments{
 \item{occdf}{\code{dataframe}. A dataframe of the fossil occurrences you
@@ -19,6 +19,12 @@ contain at least the following named columns: "bin", "max" and "min".}
 \item{lat}{\code{character}. The name of the column you wish to be treated
 as the input latitude (e.g. "lat" or "p_lat"). This column should contain
 numerical values. Defaults to "lat".}
+
+\item{boundary}{\code{logical}. If \code{TRUE}, occurrences
+falling on the boundaries of latitudinal bins will be duplicated and
+binded to the dataframe after being assigned to both bins.
+If \code{FALSE}, occurrences will be binned into the upper bin
+only (i.e. highest row number).}
 }
 \value{
 A dataframe of the original input \code{occdf} with appended

--- a/man/bin_lat.Rd
+++ b/man/bin_lat.Rd
@@ -22,7 +22,7 @@ numerical values. Defaults to "lat".}
 
 \item{boundary}{\code{logical}. If \code{TRUE}, occurrences
 falling on the boundaries of latitudinal bins will be duplicated and
-binded to the dataframe after being assigned to both bins.
+assigned to both bins.
 If \code{FALSE}, occurrences will be binned into the upper bin
 only (i.e. highest row number).}
 }

--- a/man/lat_bins.Rd
+++ b/man/lat_bins.Rd
@@ -4,19 +4,24 @@
 \alias{lat_bins}
 \title{Generate latitudinal bins}
 \usage{
-lat_bins(size = 10, fit = FALSE, plot = FALSE)
+lat_bins(size = 10, max = 90, min = -90, fit = FALSE, plot = FALSE)
 }
 \arguments{
 \item{size}{\code{numeric}. A single numeric value defining the width of the
 latitudinal bins. This value must be more than 0, and less than or equal to
-90.}
+90 (defaults to 10).}
+
+\item{max}{\code{numeric}. A single numeric value defining the upper limit
+of the latitudinal range (defaults to 90).}
+
+\item{min}{\code{numeric}. A single numeric value defining the lower limit
+of the latitudinal range (defaults to -90).}
 
 \item{fit}{\code{logical}. Should bin size be checked to ensure that the
-entire latitudinal
-range is covered (90°S to 90°N)? If \code{fit = TRUE}, bin size is
-set to the nearest integer which is divisible into 180 (the entire
-latitudinal range). If \code{fit = FALSE}, and bin size is not divisible
-into 180, part of the Northern Hemisphere latitudinal range will be missing.}
+entire latitudinal range is covered? If \code{fit = TRUE}, bin size is
+set to the nearest integer which is divisible by the user-input range.
+If \code{fit = FALSE}, and bin size is not divisible into the range, the
+upper part of the latitudinal range will be missing.}
 
 \item{plot}{\code{logical}. Should a plot of the latitudinal bins be
 generated?}
@@ -25,10 +30,10 @@ generated?}
 A \code{dataframe} of latitudinal bins of user-defined size.
 }
 \description{
-A function to generate latitudinal bins of a given size. If the desired size
-of the bins is not compatible with the entire latitudinal range
-(90°S to 90°N ), bin size can be updated to the nearest integer
-which is divisible into 180 to fit the entire range.
+A function to generate latitudinal bins of a given size for a user-defined
+latitudinal range. If the desired size of the bins is not compatible with
+the defined latitudinal range, bin size can be updated to the nearest integer
+which is divisible into this range.
 }
 \section{Developer(s)}{
 
@@ -41,10 +46,12 @@ Bethany Allen
 }
 
 \examples{
-#Generate 20 degrees latitudinal bins
+# Generate 20 degrees latitudinal bins
 bins <- lat_bins(size = 20)
 
-#Generate latitudinal bins with closest fit to 13 degrees
+# Generate latitudinal bins with closest fit to 13 degrees
 bins <- lat_bins(size = 13, fit = TRUE)
 
+# Generate latitudinal bins for defined latitudinal range
+bins <- lat_bins(size = 10, max = 50, min = -50)
 }

--- a/tests/testthat/test-bin_lat.R
+++ b/tests/testthat/test-bin_lat.R
@@ -7,6 +7,12 @@ test_that("bin_lat works", {
   expect_equal(nrow(bin_lat(occdf = occdf, bins = bins, lat = "lat")),
                nrow(occdf))
 
+  # Boundary occurrences
+  bo <- length(which(occdf[, "lat"] %in% c(bins$max, bins$min)))
+  expect_equal(nrow(bin_lat(occdf = occdf, bins = bins, lat = "lat",
+                            boundary = TRUE)),
+               nrow(occdf) + bo)
+
   # Expect error
   expect_error(bin_lat(occdf = 2, bins = bins, lat = "lat"))
   expect_error(bin_lat(occdf = occdf, bins = 2, lat = "lat"))
@@ -17,5 +23,6 @@ test_that("bin_lat works", {
   expect_error(bin_lat(occdf = occdf, bins = bins, lat = "lat"))
   occdf$lat[1] <- 91
   expect_error(bin_lat(occdf = occdf, bins = bins, lat = "lat"))
+  expect_error(bin_lat(occdf = occdf, bins = bins, lat = "latitude"))
 
 })

--- a/tests/testthat/test-lat_bins.R
+++ b/tests/testthat/test-lat_bins.R
@@ -8,6 +8,9 @@ test_that("lat_bins() works", {
 
   #expect error
   expect_error(lat_bins(size = 100))
+  expect_error(lat_bins(max = 100))
+  expect_error(lat_bins(min = 100))
+  expect_error(lat_bins(max = 10, min = 20))
   expect_error(lat_bins(fit = 1))
   expect_error(lat_bins(size = "10"))
   expect_error(lat_bins(plot = "TRUE"))


### PR DESCRIPTION
These updates enable users to:
- `lat_bins`: input a user-defined latitudinal range.
- `bin_lat`: bin occurrences into both latitudinal bins if the occurrence falls on the bin boundary. It does so by duplicating the occurrence (row).

Fixes #23. 