### PR TITLE
Fix unnecessary column output (palaeorotate)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: palaeoverse
 Title: Prepare and Explore Data for Palaeobiological Analyses
-Version: 1.1.1
+Version: 1.1.1.900
 Authors@R: c(
     person(given = "Lewis A.", family = "Jones", email = "LewisAlan.Jones@uvigo.es",
       role = c("aut", "cre"), comment = c(ORCID = "0000-0003-3902-8986")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# palaeoverse 1.1.1.900
+
+* Fixed unnecessary column output in palaeorotate (#78)
+
 # palaeoverse 1.1.1
 
 * palaeoverse now requires deeptime (>= 1.0.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,6 @@
 
 * Fixed unnecessary column output in palaeorotate (#78)
 * Fixed prior updates to "point" method in palaeorotate which introduced binding issues for some specific datasets
-* Added additional tests for palaeorotate
 
 # palaeoverse 1.1.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
-# palaeoverse 1.1.1.900
+# palaeoverse (development version)
 
 * Fixed unnecessary column output in palaeorotate (#78)
 * Fixed prior updates to "point" method in palaeorotate which introduced binding issues for some specific datasets
+* Added additional tests for palaeorotate
 
 # palaeoverse 1.1.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # palaeoverse 1.1.1.900
 
 * Fixed unnecessary column output in palaeorotate (#78)
+* Fixed prior updates to "point" method in palaeorotate which introduced binding issues for some specific datasets
 
 # palaeoverse 1.1.1
 

--- a/R/palaeorotate.R
+++ b/R/palaeorotate.R
@@ -283,9 +283,11 @@ palaeorotate <- function(occdf, lng = "lng", lat = "lat", age = "age",
   }
 
   # Create info columns for "grid" method
-  occdf$rot_age <- NA
-  occdf$rot_lng <- NA
-  occdf$rot_lat <- NA
+  if (method == "grid") {
+    occdf$rot_age <- NA
+    occdf$rot_lng <- NA
+    occdf$rot_lat <- NA
+  }
 
   # Create columns for coordinates
   mdls <- data.frame(matrix(nrow = nrow(occdf), ncol = length(model) * 2))

--- a/R/palaeorotate.R
+++ b/R/palaeorotate.R
@@ -328,7 +328,7 @@ palaeorotate <- function(occdf, lng = "lng", lat = "lat", age = "age",
     }
     # Reconstruction files
     rot_files <- list(
-      BASE = paste0(httr::GET("https://zenodo.org/record/7390065")$url,
+      BASE = paste0(GET("https://zenodo.org/record/7390065")$url,
                     "/files/"),
       MULLER2022 = "MULLER2022.RDS",
       MERDITH2021 = "MERDITH2021.RDS",
@@ -420,7 +420,7 @@ palaeorotate <- function(occdf, lng = "lng", lat = "lat", age = "age",
       },
       error = function(e) {
         stop(paste("GPlates Web Service is not available.",
-        "Either the website is down or you are not connected to the internet."),
+      "Either the website is down or you are not connected to the internet."),
              call. = FALSE)
       })
   # Define maximum chunk size for API calls
@@ -430,7 +430,7 @@ palaeorotate <- function(occdf, lng = "lng", lat = "lat", age = "age",
     # Inform user which model is running
     message(m)
     # Run across unique ages
-    rotations <- pbapply::pblapply(X = uni_ages, function(i) {
+    rotations <- pblapply(X = uni_ages, function(i) {
       # Subset to age of interest
       tmp <- coords[which(coords[, age] == i), ]
       # How many rows?
@@ -439,52 +439,56 @@ palaeorotate <- function(occdf, lng = "lng", lat = "lat", age = "age",
       chk <- seq(from = 0, to = nr + chunks, by = chunks)
       # Update final bin to equal nrow
       chk[length(chk)] <- nr
+      # If ultimate chunk is the same as penultimate, drop
+      if (chk[length(chk)] == chk[length(chk) - 1]) {
+        chk <- chk[-length(chk)]
+      }
       # Create empty df
       rot_df <- data.frame()
       # Run across chunks
       for (x in 2:length(chk)) {
-      # Lower index
-      ind_l <- chk[x - 1] + 1
-      # Upper index
-      ind_u <- chk[x]
-      # Generate API
-      tmp_chunk <- tmp[ind_l:ind_u, c(lng, lat)]
-      tmp_string <- toString(as.vector(t(tmp_chunk)))
-      api <- sprintf("?points=%s&time=%f&model=%s",
-                     gsub(" ", "", tmp_string), i, m)
-      api <- paste0("https://gws.gplates.org/reconstruct/reconstruct_points/",
-                    api, "&return_null_points")
-      # Call API
-      rots <- httr::RETRY(verb = "GET",
-                          url = api,
-                          times = 5,
-                          pause_min = 1,
-                          pause_base = 1,
-                          pause_cap = 10)
-      # Extract coordinates
-      rots <- httr::content(x = rots, as = "parsed")$coordinates
-      # Replace NULL values with NA
-      rpl <- which(rots == "NULL")
-      if (length(rpl) != 0) {
-        for (r in rpl) {
-          rots[[r]] <- list(NA, NA)
+        # Lower index
+        ind_l <- chk[x - 1] + 1
+        # Upper index
+        ind_u <- chk[x]
+        # Generate API
+        tmp_chunk <- tmp[ind_l:ind_u, c(lng, lat)]
+        tmp_string <- toString(as.vector(t(tmp_chunk)))
+        api <- sprintf("?points=%s&time=%f&model=%s",
+                       gsub(" ", "", tmp_string), i, m)
+        api <- paste0("https://gws.gplates.org/reconstruct/reconstruct_points/",
+                      api, "&return_null_points")
+        # Call API
+        rots <- RETRY(verb = "GET",
+                      url = api,
+                      times = 5,
+                      pause_min = 1,
+                      pause_base = 1,
+                      pause_cap = 10)
+        # Extract coordinates
+        rots <- content(x = rots, as = "parsed")$coordinates
+        # Replace NULL values with NA
+        rpl <- which(rots == "NULL")
+        if (length(rpl) != 0) {
+          for (r in rpl) {
+            rots[[r]] <- list(NA, NA)
+          }
         }
-      }
-      # Bind rows
-      rots <- do.call(rbind.data.frame, rots)
-      # col names
-      colnames(rots) <- c("p_lng", "p_lat")
-      # Replace modern returned coordinates with NA as some models do not
-      # return NULL when outside of time range (e.g. SETON2012)
-      rots[which(tmp_chunk[, lng] == rots[, c("p_lng")] &
-                   tmp_chunk[, lat] == rots[, c("p_lat")]),
-           c("p_lng", "p_lat")] <- NA
-      # Update col names if more than one model requested
-      if (length(model) > 1) {
-        colnames(rots) <- c(paste0("p_lng_", m), paste0("p_lat_", m))
-      }
-      # Bind output
-      rot_df <- rbind.data.frame(rot_df, rots)
+        # Bind rows
+        rots <- do.call(rbind.data.frame, rots)
+        # col names
+        colnames(rots) <- c("p_lng", "p_lat")
+        # Replace modern returned coordinates with NA as some models do not
+        # return NULL when outside of time range (e.g. SETON2012)
+        rots[which(tmp_chunk[, lng] == rots[, c("p_lng")] &
+                     tmp_chunk[, lat] == rots[, c("p_lat")]),
+             c("p_lng", "p_lat")] <- NA
+        # Update col names if more than one model requested
+        if (length(model) > 1) {
+          colnames(rots) <- c(paste0("p_lng_", m), paste0("p_lat_", m))
+        }
+        # Bind output
+        rot_df <- rbind.data.frame(rot_df, rots)
       }
       # Return df
       rot_df
@@ -551,8 +555,7 @@ palaeorotate <- function(occdf, lng = "lng", lat = "lat", age = "age",
           next
       } else {
         # Calculate GCD matrix
-        dist <- geosphere::distm(x = tmpdf,
-                                 fun = geosphere::distGeo)
+        dist <- distm(x = tmpdf, fun = distGeo)
         # Convert to km
         dist <- dist / 10^3
         # Get maximum GCD in km

--- a/R/palaeorotate.R
+++ b/R/palaeorotate.R
@@ -439,6 +439,8 @@ palaeorotate <- function(occdf, lng = "lng", lat = "lat", age = "age",
       chk <- seq(from = 0, to = nr + chunks, by = chunks)
       # Update final bin to equal nrow
       chk[length(chk)] <- nr
+      # Create empty df
+      rot_df <- data.frame()
       # Run across chunks
       for (x in 2:length(chk)) {
       # Lower index
@@ -447,9 +449,9 @@ palaeorotate <- function(occdf, lng = "lng", lat = "lat", age = "age",
       ind_u <- chk[x]
       # Generate API
       tmp_chunk <- tmp[ind_l:ind_u, c(lng, lat)]
-      tmp_chunk <- toString(as.vector(t(tmp_chunk)))
+      tmp_string <- toString(as.vector(t(tmp_chunk)))
       api <- sprintf("?points=%s&time=%f&model=%s",
-                     gsub(" ", "", tmp_chunk), i, m)
+                     gsub(" ", "", tmp_string), i, m)
       api <- paste0("https://gws.gplates.org/reconstruct/reconstruct_points/",
                     api, "&return_null_points")
       # Call API
@@ -474,14 +476,18 @@ palaeorotate <- function(occdf, lng = "lng", lat = "lat", age = "age",
       colnames(rots) <- c("p_lng", "p_lat")
       # Replace modern returned coordinates with NA as some models do not
       # return NULL when outside of time range (e.g. SETON2012)
-      rots[which(tmp[, lng] == rots[, c("p_lng")] &
-            tmp[, lat] == rots[, c("p_lat")]), c("p_lng", "p_lat")] <- NA
+      rots[which(tmp_chunk[, lng] == rots[, c("p_lng")] &
+                   tmp_chunk[, lat] == rots[, c("p_lat")]),
+           c("p_lng", "p_lat")] <- NA
       # Update col names if more than one model requested
       if (length(model) > 1) {
         colnames(rots) <- c(paste0("p_lng_", m), paste0("p_lat_", m))
       }
-    }
-      rots
+      # Bind output
+      rot_df <- rbind.data.frame(rot_df, rots)
+      }
+      # Return df
+      rot_df
     })
     # Bind data
     rotations <- do.call(rbind, rotations)

--- a/R/palaeorotate.R
+++ b/R/palaeorotate.R
@@ -423,101 +423,103 @@ palaeorotate <- function(occdf, lng = "lng", lat = "lat", age = "age",
       "Either the website is down or you are not connected to the internet."),
              call. = FALSE)
       })
-  # Define maximum chunk size for API calls
-  chunks <- 300
-  # Run across models
-  for (m in model) {
-    # Inform user which model is running
-    message(m)
-    # Run across unique ages
-    rotations <- pblapply(X = uni_ages, function(i) {
-      # Subset to age of interest
-      tmp <- coords[which(coords[, age] == i), ]
-      # How many rows?
-      nr <- nrow(tmp)
-      # Generate chunk bins
-      chk <- seq(from = 0, to = nr + chunks, by = chunks)
-      # Update final bin to equal nrow
-      chk[length(chk)] <- nr
-      # If ultimate chunk is the same as penultimate, drop
-      if (chk[length(chk)] == chk[length(chk) - 1]) {
-        chk <- chk[-length(chk)]
-      }
-      # Create empty df
-      rot_df <- data.frame()
-      # Run across chunks
-      for (x in 2:length(chk)) {
-        # Lower index
-        ind_l <- chk[x - 1] + 1
-        # Upper index
-        ind_u <- chk[x]
-        # Generate API
-        tmp_chunk <- tmp[ind_l:ind_u, c(lng, lat)]
-        tmp_string <- toString(as.vector(t(tmp_chunk)))
-        api <- sprintf("?points=%s&time=%f&model=%s",
-                       gsub(" ", "", tmp_string), i, m)
-        api <- paste0("https://gws.gplates.org/reconstruct/reconstruct_points/",
-                      api, "&return_null_points")
-        # Call API
-        rots <- RETRY(verb = "GET",
-                      url = api,
-                      times = 5,
-                      pause_min = 1,
-                      pause_base = 1,
-                      pause_cap = 10)
-        # Extract coordinates
-        rots <- content(x = rots, as = "parsed")$coordinates
-        # Replace NULL values with NA
-        rpl <- which(rots == "NULL")
-        if (length(rpl) != 0) {
-          for (r in rpl) {
-            rots[[r]] <- list(NA, NA)
+    # Define maximum chunk size for API calls
+    chunks <- 300
+    # Run across models
+    for (m in model) {
+      # Inform user which model is running
+      message(m)
+      # Run across unique ages
+      rotations <- pblapply(X = uni_ages, function(i) {
+        # Subset to age of interest
+        tmp <- coords[which(coords[, age] == i), ]
+        # How many rows?
+        nr <- nrow(tmp)
+        # Generate chunk bins
+        chk <- seq(from = 0, to = nr + chunks, by = chunks)
+        # Update final bin to equal nrow
+        chk[length(chk)] <- nr
+        # If ultimate chunk is the same as penultimate, drop
+        if (chk[length(chk)] == chk[length(chk) - 1]) {
+          chk <- chk[-length(chk)]
+        }
+        # Create empty df
+        rot_df <- data.frame()
+        # Run across chunks
+        for (x in 2:length(chk)) {
+          # Lower index
+          ind_l <- chk[x - 1] + 1
+          # Upper index
+          ind_u <- chk[x]
+          # Generate API
+          tmp_chunk <- tmp[ind_l:ind_u, c(lng, lat)]
+          tmp_string <- toString(as.vector(t(tmp_chunk)))
+          api <- sprintf("?points=%s&time=%f&model=%s",
+                         gsub(" ", "", tmp_string), i, m)
+          api <- paste0("https://gws.gplates.org/reconstruct/",
+                        "reconstruct_points/",
+                        api, "&return_null_points")
+          # Call API
+          rots <- RETRY(verb = "GET",
+                        url = api,
+                        times = 5,
+                        pause_min = 1,
+                        pause_base = 1,
+                        pause_cap = 10)
+          # Extract coordinates
+          rots <- content(x = rots, as = "parsed")$coordinates
+          # Replace NULL values with NA
+          rpl <- which(rots == "NULL")
+          if (length(rpl) != 0) {
+            for (r in rpl) {
+              rots[[r]] <- list(NA, NA)
+            }
           }
+          # Bind rows
+          rots <- do.call(rbind.data.frame, rots)
+          # col names
+          colnames(rots) <- c("p_lng", "p_lat")
+          # Replace modern returned coordinates with NA as some models do not
+          # return NULL when outside of time range (e.g. SETON2012)
+          rots[which(tmp_chunk[, lng] == rots[, c("p_lng")] &
+                       tmp_chunk[, lat] == rots[, c("p_lat")]),
+               c("p_lng", "p_lat")] <- NA
+          # Update col names if more than one model requested
+          if (length(model) > 1) {
+            colnames(rots) <- c(paste0("p_lng_", m), paste0("p_lat_", m))
+          }
+          # Bind output
+          rot_df <- rbind.data.frame(rot_df, rots)
         }
-        # Bind rows
-        rots <- do.call(rbind.data.frame, rots)
-        # col names
-        colnames(rots) <- c("p_lng", "p_lat")
-        # Replace modern returned coordinates with NA as some models do not
-        # return NULL when outside of time range (e.g. SETON2012)
-        rots[which(tmp_chunk[, lng] == rots[, c("p_lng")] &
-                     tmp_chunk[, lat] == rots[, c("p_lat")]),
-             c("p_lng", "p_lat")] <- NA
-        # Update col names if more than one model requested
-        if (length(model) > 1) {
-          colnames(rots) <- c(paste0("p_lng_", m), paste0("p_lat_", m))
-        }
-        # Bind output
-        rot_df <- rbind.data.frame(rot_df, rots)
-      }
-      # Return df
-      rot_df
-    })
-    # Bind data
-    rotations <- do.call(rbind, rotations)
-    coords <- cbind.data.frame(coords, rotations)
-  }
+        # Return df
+        rot_df
+      })
+      # Bind data
+      rotations <- do.call(rbind, rotations)
+      coords <- cbind.data.frame(coords, rotations)
+    }
 
-  # Set-up matching
-  coords$match <- paste0(coords[, lng],
-                         coords[, lat],
-                         coords[, age])
-  occdf$match <- paste0(occdf[, lng],
-                        occdf[, lat],
-                        occdf[, age])
+    # Set-up matching
+    coords$match <- paste0(coords[, lng],
+                           coords[, lat],
+                           coords[, age])
+    occdf$match <- paste0(occdf[, lng],
+                          occdf[, lat],
+                          occdf[, age])
 
-  # Match data
-  mch <- match(x = occdf$match, table = coords$match)
+    # Match data
+    mch <- match(x = occdf$match, table = coords$match)
 
-  occdf[, colnames(coords)] <- coords[mch, ]
+    occdf[, colnames(coords)] <- coords[mch, ]
 
-  # Drop match column
-  occdf <- occdf[, -which(colnames(occdf) == "match")]
+    # Drop match column
+    occdf <- occdf[, -which(colnames(occdf) == "match")]
 
-  # Drop model palaeocoordinate column if only one model selected
-  if (length(model) == 1) {
-    occdf <- occdf[, -c(which(colnames(occdf) %in% c(paste0("p_lng_", model),
-                                            paste0("p_lat_", model))))]
+    # Drop model palaeocoordinate column if only one model selected
+    if (length(model) == 1) {
+      occdf <- occdf[, -c(which(colnames(occdf) %in%
+                                  c(paste0("p_lng_", model),
+                                    paste0("p_lat_", model))))]
     }
   }
 

--- a/tests/testthat/test-palaeorotate.R
+++ b/tests/testthat/test-palaeorotate.R
@@ -10,8 +10,30 @@ test_that("palaeorotate() point method works", {
                                  method = "point",
                                  model = "PALEOMAP")), 3)
 
+  expect_equal(nrow(palaeorotate(occdf = occdf,
+                                 method = "point",
+                                 model = "PALEOMAP")), 3)
+
   expect_equal(nrow(palaeorotate(occdf = occdf, method = "point",
                                  round = 2)), 3)
+
+
+  # Check chunk size is working
+  occdf <- data.frame(lng = runif(1500, -180, 180),
+                      lat = runif(1500, -90, 90),
+                      age = rep(100, 1500))
+
+  expect_warning(occdf <- palaeorotate(occdf = occdf,
+                                       method = "point",
+                                       model = "PALEOMAP",
+                                       round = 3), NULL)
+  # Filter out points that can't be reconstructed
+  occdf <- occdf[-which(is.na(occdf$p_lng)), ]
+
+  expect_equal(nrow(palaeorotate(occdf = occdf,
+                                 method = "point",
+                                 model = "PALEOMAP")), nrow(occdf))
+
 
   # Expect message
   occdf <- data.frame(lng = c(-41),


### PR DESCRIPTION
This PR fixes the unnecessary column output (rot_age, rot_lng and rot_lat) in the palaeorotate function when using the "point" method. It is a small 'bug', but annoying none the less. 

Closes #78.