### PR TITLE
update description and example of axis_geo

### DIFF
--- a/R/axis_geo.R
+++ b/R/axis_geo.R
@@ -57,7 +57,9 @@
 #' @param intervals The interval information to use to plot the axis: either A)
 #'   a \code{character} string indicating a built-in or remotely hosted
 #'   \code{data.frame} (see \code{\link[deeptime]{get_scale_data}}), or B) a
-#'   custom \code{data.frame} of time interval boundaries (see Details).
+#'   custom \code{data.frame} of time interval boundaries. A list
+#'   of strings or data.frames can be supplied to add multiple time scales to
+#'   the same side of the plot (see Details).
 #' @param height \code{numeric}. The relative height (or width if \code{side} is
 #'   \code{2} or \code{4}) of the scale. This is relative to the height (if
 #'   \code{side} is \code{1} or \code{3}) or width (if \code{side} is \code{2}
@@ -149,13 +151,14 @@
 #' # the line argument here depends on the absolute size of the plot
 #' title(xlab = "Time (Ma)", line = 4)
 #'
-#' # stack multiple scales
+#' # stack multiple scales, abbreviate only one set of labels
 #' par(mar = c(7.1, 4.1, 4.1, 2.1)) # further expand bottom margin
 #' plot(0:100, axes = FALSE, xlim = c(100, 0), ylim = c(100, 0),
 #'      xlab = NA, ylab = "Depth (m)")
 #' box()
 #' axis(2)
-#' axis_geo(side = 1, intervals = list("epochs", "periods"))
+#' axis_geo(side = 1, intervals = list("epochs", "periods"),
+#'     abbr = list(TRUE, FALSE))
 #' # the line argument here depends on the absolute size of the plot
 #' title(xlab = "Time (Ma)", line = 6)
 #'

--- a/man/axis_geo.Rd
+++ b/man/axis_geo.Rd
@@ -40,7 +40,9 @@ the default; \code{2}: left; \code{3}: top; \code{4}: right).}
 \item{intervals}{The interval information to use to plot the axis: either A)
 a \code{character} string indicating a built-in or remotely hosted
 \code{data.frame} (see \code{\link[deeptime]{get_scale_data}}), or B) a
-custom \code{data.frame} of time interval boundaries (see Details).}
+custom \code{data.frame} of time interval boundaries. A list
+of strings or data.frames can be supplied to add multiple time scales to
+the same side of the plot (see Details).}
 
 \item{height}{\code{numeric}. The relative height (or width if \code{side} is
 \code{2} or \code{4}) of the scale. This is relative to the height (if
@@ -210,13 +212,14 @@ axis_geo(side = 1, intervals = "periods")
 # the line argument here depends on the absolute size of the plot
 title(xlab = "Time (Ma)", line = 4)
 
-# stack multiple scales
+# stack multiple scales, abbreviate only one set of labels
 par(mar = c(7.1, 4.1, 4.1, 2.1)) # further expand bottom margin
 plot(0:100, axes = FALSE, xlim = c(100, 0), ylim = c(100, 0),
      xlab = NA, ylab = "Depth (m)")
 box()
 axis(2)
-axis_geo(side = 1, intervals = list("epochs", "periods"))
+axis_geo(side = 1, intervals = list("epochs", "periods"),
+    abbr = list(TRUE, FALSE))
 # the line argument here depends on the absolute size of the plot
 title(xlab = "Time (Ma)", line = 6)
 


### PR DESCRIPTION
# Function name

## Description

Slightly expand the documentation and one example of `axis_geo()` to make it easier to find that multiple scales can be added to the same side, which can all be modified by using lists for other function arguments.

## Motivation and Context

A user has emailed me, asking how he can modify the labels to have only one set of labels abbreviated. Although this is stated in the _Details_, I think it will be easier to find if this case is included in one of the examples. I've also added the possibility of list inputs to the _interval_ argument, for similar reasons.

- [x] I have added function documentation.

