### PR TITLE
Fix multi-model call bug in palaeorotate (#82)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Fixed unnecessary column output in palaeorotate (#78)
 * Fixed prior updates to "point" method in palaeorotate which introduced binding issues for some specific datasets
+* Fixed multi-model call in palaeorotate for the "point" method which did not return all requested model coordinates
 
 # palaeoverse 1.1.1
 

--- a/R/palaeorotate.R
+++ b/R/palaeorotate.R
@@ -202,8 +202,7 @@
 #' ex4 <- palaeorotate(occdf = tetrapods,
 #'                     model = c("MERDITH2021",
 #'                               "GOLONKA",
-#'                               "PALEOMAP",
-#'                               "SETON2012"),
+#'                               "PALEOMAP"),
 #'                     uncertainty = TRUE)
 #' }
 #' @export
@@ -496,7 +495,8 @@ palaeorotate <- function(occdf, lng = "lng", lat = "lat", age = "age",
         rot_df
       })
       # Bind data
-      coords <- do.call(rbind, rotations)
+      model_coords <- do.call(rbind, rotations)
+      coords <- cbind(coords, model_coords[, 4:5])
     }
 
     # Set-up matching

--- a/man/palaeorotate.Rd
+++ b/man/palaeorotate.Rd
@@ -241,8 +241,7 @@ ex3 <- palaeorotate(occdf = tetrapods)
 ex4 <- palaeorotate(occdf = tetrapods,
                     model = c("MERDITH2021",
                               "GOLONKA",
-                              "PALEOMAP",
-                              "SETON2012"),
+                              "PALEOMAP"),
                     uncertainty = TRUE)
 }
 }

--- a/tests/testthat/test-palaeorotate.R
+++ b/tests/testthat/test-palaeorotate.R
@@ -17,6 +17,17 @@ test_that("palaeorotate() point method works", {
   expect_equal(nrow(palaeorotate(occdf = occdf, method = "point",
                                  round = 2)), 3)
 
+  # Expect warning
+  expect_warning(palaeorotate(occdf = occdf,
+                              method = "point",
+                              model = "MULLER2022"), NULL)
+
+  # Check that multiple models are being returned
+  occdf <- palaeorotate(occdf = occdf,
+                        method = "point",
+                        model = c("PALEOMAP", "GOLONKA"),
+                        uncertainty = FALSE)
+  expect_false(any(is.na(occdf)))
 
   # Check chunk size is working
   occdf <- data.frame(lng = runif(1500, -180, 180),
@@ -35,7 +46,7 @@ test_that("palaeorotate() point method works", {
                                  model = "PALEOMAP")), nrow(occdf))
 
 
-  # Expect message
+  # Expect error
   occdf <- data.frame(lng = c(-41),
                       lat = c(37),
                       age = c(300))
@@ -46,8 +57,6 @@ test_that("palaeorotate() point method works", {
 
   expect_error(palaeorotate(occdf = occdf, method = "point",
                             model = "WRIGHT2013"))
-
-
 })
 
 test_that("palaeorotate() grid method works", {


### PR DESCRIPTION
Multi-model call in palaeorotate for the "point" method does not return all requested model coordinates, only the last called model. I've implemented a fix for this and added additional tests to catch this in future.

Closes #82. 