### PR TITLE
Added ability to use custom bins for tax_expand_time

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Fixed handling of multiple models in palaeorotate (#92)
 * Fixed custom ticks behavior for axis_geo_phylo
+* Added ability to use custom bins for tax_expand_time (#94)
 
 # palaeoverse 1.2.0
 

--- a/R/tax_expand_time.R
+++ b/R/tax_expand_time.R
@@ -19,10 +19,19 @@
 #'   as the maximum limit (FADs) of the age range (e.g. "max_ma").
 #' @param min_ma \code{character}. The name of the column you wish to be treated
 #'   as the minimum limit (LADs) of the age range (e.g. "min_ma").
-#' @param scale \code{character}. Specify the desired geological timescale to
-#'   be used, either "GTS2020" or "GTS2012".
+#' @param bins \code{dataframe}. A dataframe of the bins that you wish to
+#'   allocate pseudo-occurrences to such as that returned by
+#'   \code{\link[palaeoverse:time_bins]{time_bins()}}. This dataframe must
+#'   contain at least the following named columns: "bin", "max_ma" and
+#'   "min_ma". Columns "max_ma" and "min_ma" must be `numeric` values.
+#' @param scale \code{character}. Specify the desired geological timescale to be
+#'   used, either "GTS2020" or "GTS2012". Passed to
+#'   \code{\link[palaeoverse:time_bins]{time_bins()}} if \code{bins} is not
+#'   specified.
 #' @param rank \code{character}. Specify the desired stratigraphic rank. Choose
-#'   from: "stage", "epoch", "period", "era", and "eon".
+#'   from: "stage", "epoch", "period", "era", and "eon". Passed to
+#'   \code{\link[palaeoverse:time_bins]{time_bins()}} if \code{bins} is not
+#'   specified.
 #' @param ext_orig \code{logical}. Should two additional columns be added to
 #'   identify the intervals in which taxa originated and went extinct?
 #'
@@ -46,6 +55,7 @@ tax_expand_time <- function(
     taxdf,
     max_ma = "max_ma",
     min_ma = "min_ma",
+    bins = NULL,
     scale = "GTS2020",
     rank = "stage",
     ext_orig = TRUE) {
@@ -82,32 +92,36 @@ tax_expand_time <- function(
     stop("`ext_orig` should be logical (TRUE/FALSE)")
   }
 
-  # get the desired timescale at the desired rank
-  if (scale == "GTS2020") {
-    timescale <- palaeoverse::GTS2020
-  } else if (scale == "GTS2012") {
-    timescale <- palaeoverse::GTS2012
+  if (is.null(bins) && (is.null(scale) || is.null(rank))) {
+    stop("Either `bin` or `scale` and `rank` must be specified.")
+  }
+  if (!is.null(bins)) {
+    if (is.data.frame(bins) == FALSE) {
+      stop("`bins` should be a dataframe.")
+    }
+    if (!all(c("bin", "max_ma", "min_ma") %in% colnames(bins))) {
+      stop("bin, max_ma and/or min_ma do not exist in `bins`.")
+    }
   } else {
-    stop('`scale` should be "GTS2020" or "GTS2012"')
+    # get the desired timescale at the desired rank
+    bins <- time_bins(rank = rank, scale = scale)
   }
 
   if (any(duplicated(taxdf))) {
     stop("Not all rows in `taxdf` are unique!")
   }
 
-  intervals <- timescale[timescale$rank == rank, ]
-
   # replicate taxon rows for each interval they span
-  dat_list <- lapply(seq_len(nrow(intervals)), function(i) {
-    int_tax <- taxdf[taxdf[, min_ma] < intervals$max_ma[i] &
-                       taxdf[, max_ma] > intervals$min_ma[i], ]
+  dat_list <- lapply(seq_len(nrow(bins)), function(i) {
+    int_tax <- taxdf[taxdf[, min_ma] < bins$max_ma[i] &
+                       taxdf[, max_ma] > bins$min_ma[i], ]
     if (ext_orig) {
-      int_tax$ext <- int_tax[, min_ma] >= intervals$min_ma[i] &
+      int_tax$ext <- int_tax[, min_ma] >= bins$min_ma[i] &
                        int_tax[, min_ma] > 0
-      int_tax$orig <- int_tax[, max_ma] <= intervals$max_ma[i]
+      int_tax$orig <- int_tax[, max_ma] <= bins$max_ma[i]
     }
     if (nrow(int_tax) == 0) return(NULL)
-    cbind(int_tax, intervals[i, ])
+    cbind(int_tax, bins[i, ])
   })
   dat <- do.call(rbind, dat_list)
   rownames(dat) <- NULL

--- a/man/tax_expand_time.Rd
+++ b/man/tax_expand_time.Rd
@@ -8,6 +8,7 @@ tax_expand_time(
   taxdf,
   max_ma = "max_ma",
   min_ma = "min_ma",
+  bins = NULL,
   scale = "GTS2020",
   rank = "stage",
   ext_orig = TRUE
@@ -28,11 +29,21 @@ as the maximum limit (FADs) of the age range (e.g. "max_ma").}
 \item{min_ma}{\code{character}. The name of the column you wish to be treated
 as the minimum limit (LADs) of the age range (e.g. "min_ma").}
 
-\item{scale}{\code{character}. Specify the desired geological timescale to
-be used, either "GTS2020" or "GTS2012".}
+\item{bins}{\code{dataframe}. A dataframe of the bins that you wish to
+allocate pseudo-occurrences to such as that returned by
+\code{\link[palaeoverse:time_bins]{time_bins()}}. This dataframe must
+contain at least the following named columns: "bin", "max_ma" and
+"min_ma". Columns "max_ma" and "min_ma" must be \code{numeric} values.}
+
+\item{scale}{\code{character}. Specify the desired geological timescale to be
+used, either "GTS2020" or "GTS2012". Passed to
+\code{\link[palaeoverse:time_bins]{time_bins()}} if \code{bins} is not
+specified.}
 
 \item{rank}{\code{character}. Specify the desired stratigraphic rank. Choose
-from: "stage", "epoch", "period", "era", and "eon".}
+from: "stage", "epoch", "period", "era", and "eon". Passed to
+\code{\link[palaeoverse:time_bins]{time_bins()}} if \code{bins} is not
+specified.}
 
 \item{ext_orig}{\code{logical}. Should two additional columns be added to
 identify the intervals in which taxa originated and went extinct?}

--- a/tests/testthat/test-tax_expand_time.R
+++ b/tests/testthat/test-tax_expand_time.R
@@ -6,19 +6,25 @@ test_that("tax_expand_time() works", {
   result1 <- tax_expand_time(taxdf)
   result2 <- tax_expand_time(taxdf, ext_orig = FALSE)
   result3 <- tax_expand_time(taxdf, scale = "GTS2012")
+  result4 <- tax_expand_time(taxdf, bins = time_bins(scale = "GTS2020"))
 
   # format
   expect_true(is.data.frame(result1))
   expect_equal(nrow(result1), 34)
   expect_equal(colnames(result1),
-               c(colnames(taxdf), "ext", "orig", colnames(GTS2020)))
-  expect_equal(colnames(result2), c(colnames(taxdf), colnames(GTS2020)))
+               c(colnames(taxdf), "ext", "orig",
+                 colnames(time_bins(scale = "GTS2020", rank = "stage"))))
+  expect_equal(colnames(result2),
+               c(colnames(taxdf),
+                 colnames(time_bins(scale = "GTS2020", rank = "stage"))))
   expect_equal(nrow(result3), 32)
+  expect_equal(result1, result4)
 
   # error handling
   expect_error(tax_expand_time(taxdf, scale = "GTS2067"))
   expect_error(tax_expand_time(taxdf, rank = "stages"))
   expect_error(tax_expand_time(taxdf, rank = c("stage", "period")))
+  expect_error(tax_expand_time(taxdf, bins = "stages"))
   expect_error(tax_expand_time(taxdf, ext_orig = "ext"))
   expect_error(tax_expand_time(c("A", "B")))
 


### PR DESCRIPTION
This adds the ability to use a custom set of temporal bins for the `tax_expand_time` function. It now behaves just like `tax_expand_lat` and `bin_time`. The old arguments are maintained for backwards-compatibility (and are just passed to `time_bins` for convenience).