### PR TITLE
Fix stale links in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to palaeoverse
 
-At `palaeoverse` we have adopted a set of [structures and standards](https://palaeoverse.org/articles/structure-and-standards.html) to follow for contributing to the development of `palaeoverse`. If you would like to contribute to the `palaeoverse` toolkit, we strongly advise reading this document first. If you plan to contribute a function to `palaeoverse`, you should first raise an [issue](https://github.com/palaeoverse/palaeoverse/issues) via the GitHub repository. This way the development team can assess whether the function is suitable or needed in the `palaeoverse` toolkit prior to submission.
+At `palaeoverse` we have adopted a set of [structures and standards](https://palaeoverse.palaeoverse.org/articles/structure-and-standards.html) to follow for contributing to the development of `palaeoverse`. If you would like to contribute to the `palaeoverse` toolkit, we strongly advise reading this document first. If you plan to contribute a function to `palaeoverse`, you should first raise an [issue](https://github.com/palaeoverse/palaeoverse/issues) via the GitHub repository. This way the development team can assess whether the function is suitable or needed in the `palaeoverse` toolkit prior to submission.
 
 ## How to contribute
 
@@ -46,4 +46,4 @@ We appreciate that GitHub is not a platform for everyone and have set up a [Goog
 
 ## Code of Conduct
 
-Please note that by contributing to `palaeoverse` you agree to our [Code of Conduct](https://palaeoverse.org/CODE_OF_CONDUCT.html).
+Please note that by contributing to `palaeoverse` you agree to our [Code of Conduct](https://palaeoverse.org/conduct.html).

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ As with any community project, society, or meeting we feel it is important to es
 
 If you use the palaeoverse R package in your work, please cite as:
 
-Jones, L.A., Gearty, W., Allen, B.J., Eichenseer, K., Dean, C.D., Galván S., Kouvari, M., Godoy, P.L., Nicholl, C., Dillon, E.M., Flannery-Sutherland, J.T., Chiarenza, A.A. 2023. palaeoverse: A community-driven R package to support palaeobiological analysis. *Methods in Ecology and Evolution* 14(09), 2205--2215. doi: [10.1111/2041-210X.14099](https://doi.org/10.1111/2041-210X.14099).
+Jones, L.A., Gearty, W., Allen, B.J., Eichenseer, K., Dean, C.D., Galván S., Kouvari, M., Godoy, P.L., Nicholl, C., Dillon, E.M., Flannery-Sutherland, J.T., Chiarenza, A.A. 2023. palaeoverse: A community-driven R package to support palaeobiological analysis. *Methods in Ecology and Evolution* 14(09), 2205--2215. doi: [10.1111/2041-210X.14099](https://besjournals.onlinelibrary.wiley.com/doi/10.1111/2041-210X.14099).
 
 <p align="left">
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![codecov](https://codecov.io/gh/palaeoverse/palaeoverse/branch/main/graph/badge.svg?token=HQQO2CRIKT)](https://app.codecov.io/gh/palaeoverse/palaeoverse)
 [![CRAN status](https://www.r-pkg.org/badges/version/palaeoverse)](https://CRAN.R-project.org/package=palaeoverse)
 [![CRAN downloads](https://cranlogs.r-pkg.org/badges/grand-total/palaeoverse)](https://cran.r-project.org/package=palaeoverse)
-[![Twitter URL](https://img.shields.io/twitter/url/https/twitter.com/ThePalaeoverse.svg?style=social&label=Follow%20%40ThePalaeoverse)](https://twitter.com/ThePalaeoverse)
+[![Bluesky URL](https://img.shields.io/badge/Bluesky-0285FF?logo=bluesky&logoColor=fff&label=Follow%20%40palaeoverse)](https://bsky.app/profile/palaeoverse.bsky.social)
 <!-- badges: end -->
 
 `palaeoverse` is an R package developed by palaeobiologists, for palaeobiologists.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ As with any community project, society, or meeting we feel it is important to es
 
 If you use the palaeoverse R package in your work, please cite as:
 
-Jones, L.A., Gearty, W., Allen, B.J., Eichenseer, K., Dean, C.D., Galván S., Kouvari, M., Godoy, P.L., Nicholl, C., Dillon, E.M., Flannery-Sutherland, J.T., Chiarenza, A.A. 2023. palaeoverse: A community-driven R package to support palaeobiological analysis. *Methods in Ecology and Evolution* 14(09), 2205--2215. doi: [10.1111/2041-210X.14099](https://besjournals.onlinelibrary.wiley.com/doi/10.1111/2041-210X.14099).
+Jones, L.A., Gearty, W., Allen, B.J., Eichenseer, K., Dean, C.D., Galván S., Kouvari, M., Godoy, P.L., Nicholl, C., Dillon, E.M., Flannery-Sutherland, J.T., Chiarenza, A.A. 2023. palaeoverse: A community-driven R package to support palaeobiological analysis. *Methods in Ecology and Evolution* 14(09), 2205--2215. doi: [10.1111/2041-210X.14099](https://doi.org/10.1111/2041-210X.14099).
 
 <p align="left">
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![CRAN status](https://www.r-pkg.org/badges/version/palaeoverse)](https://CRAN.R-project.org/package=palaeoverse)
 [![CRAN downloads](https://cranlogs.r-pkg.org/badges/grand-total/palaeoverse)](https://cran.r-project.org/package=palaeoverse)
 [![Bluesky URL](https://img.shields.io/badge/Bluesky-0285FF?logo=bluesky&logoColor=fff&label=Follow%20%40palaeoverse)](https://bsky.app/profile/palaeoverse.bsky.social)
+[![LinkedIn](https://custom-icon-badges.demolab.com/badge/LinkedIn-0A66C2?logo=linkedin-white&logoColor=fff&label=Follow%20%40Palaeoverse)](https://linkedin.com/company/palaeoverse)
 <!-- badges: end -->
 
 `palaeoverse` is an R package developed by palaeobiologists, for palaeobiologists.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -9,7 +9,7 @@ Please include a summary of your function.
 Please include a summary of the motivation and context of this function.
 
 ## Checklist before requesting a review
-- [ ] I have read palaeoverse's [standards and structure](https://palaeoverse.org/articles/structure-and-standards.html) 
+- [ ] I have read palaeoverse's [standards and structure](https://palaeoverse.palaeoverse.org/articles/structure-and-standards.html)
 - [ ] I have performed a self-review of my code.
 - [ ] I have added function documentation.
 - [ ] I have provided sufficient examples of implementation.


### PR DESCRIPTION
# Function name

## Description

Related to #148. I've run `urlchecker` and `lychee` locally but they both have false positives, which is why I haven't added a CI workflow for this yet:

* `urlchecker` keeps reporting https://img.shields.io/twitter/url.svg?style=social&label=Follow%20%40ThePalaeoverse&url=https%3A%2F%2Ftwitter.com%2FThePalaeoverse as 403 (Forbidden) but this link is valid
* `lychee` reports https://besjournals.onlinelibrary.wiley.com/doi/10.1111/2041-210X.14099 as 403 (Forbidden) but it also works. It might be due to Cloudflare check?

I guess #148 shouldn't be closed until we have proper CI to check dead links.

Also, I just updated the URL to the "Structure and standards" so that it's no longer stale, but we probably want this to be stored on the Palaeoverse website and not on `palaeoverse` website, so this change might need to be reverted later.	

## Motivation and Context



## Checklist before requesting a review
- [x] I have read palaeoverse's [standards and structure](https://palaeoverse.org/articles/structure-and-standards.html) 
- [x] I have performed a self-review of my code.
- [ ] I have added function documentation.
- [ ] I have provided sufficient examples of implementation.
- [ ] If it is a core feature, I have added thorough tests.

