### PR TITLE
Run `testthat` in parallel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -67,6 +67,7 @@ Suggests:
     covr
 VignetteBuilder: knitr
 Config/testthat/edition: 3
+Config/testthat/parallel: true
 URL: https://palaeoverse.palaeoverse.org,
      https://github.com/palaeoverse/palaeoverse,
      https://palaeoverse.org


### PR DESCRIPTION
Locally, running without parallel testing takes 96s and running with parallel testing takes 62s (there could be more gains due to parallelization later on, `test-palaeorotate.R` clearly is the bottleneck). This is also visible in CI.

Part of #161 

## Checklist before requesting a review
- [x] I have read palaeoverse's [standards and structure](https://palaeoverse.palaeoverse.org/articles/structure-and-standards.html)
- [x] I have performed a self-review of my code.
- [ ] I have added function documentation.
- [ ] I have provided sufficient examples of implementation.
- [ ] If it is a core feature, I have added thorough tests.

