### PR TITLE
Deactivate `lintr` rules related to formatting

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,7 +26,25 @@ jobs:
           needs: lint
 
       - name: Lint
-        run: lintr::lint_package()
+        run: |
+          # Air takes care of all formatting so we deactivate all formatting-related rules
+          lint_package(linters = linters_with_defaults(
+            absolute_path_linter = NULL,
+            brace_linter = NULL,
+            commas_linter = NULL,
+            commas_linter = NULL,
+            function_left_parenthesis_linter = NULL,
+            indentation_linter = NULL,
+            infix_spaces_linter = NULL,
+            line_length_linter = NULL,
+            paren_body_linter = NULL,
+            semicolon_linter = NULL,
+            spaces_inside_linter = NULL,
+            spaces_left_parentheses_linter = NULL,
+            trailing_blank_lines_linter = NULL,
+            trailing_whitespace_linter = NULL,
+            whitespace_linter = NULL
+          ))
         shell: Rscript {0}
         env:
           LINTR_ERROR_ON_LINT: false

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Lint
         run: |
           # Air takes care of all formatting so we deactivate all formatting-related rules
-          lint_package(linters = linters_with_defaults(
+          lintr::lint_package(linters = lintr::linters_with_defaults(
             absolute_path_linter = NULL,
             brace_linter = NULL,
             commas_linter = NULL,

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,6 @@ jobs:
             absolute_path_linter = NULL,
             brace_linter = NULL,
             commas_linter = NULL,
-            commas_linter = NULL,
             function_left_parenthesis_linter = NULL,
             indentation_linter = NULL,
             infix_spaces_linter = NULL,

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,7 @@ jobs:
             absolute_path_linter = NULL,
             brace_linter = NULL,
             commas_linter = NULL,
-            function_left_parenthesis_linter = NULL,
+            function_left_parentheses_linter = NULL,
             indentation_linter = NULL,
             infix_spaces_linter = NULL,
             line_length_linter = NULL,


### PR DESCRIPTION
Follow-up of #170, cf https://github.com/palaeoverse/palaeoverse/pull/170#issuecomment-4486159153

There is probably more tweaking needed because Jarl isn't a one-to-one replacement of `lintr` yet, but I think this can be addressed later on. I just wanted to get rid of those linting rules since they are now covered by Air.

Part of #165

## Checklist before requesting a review
- [x] I have read palaeoverse's [standards and structure](https://palaeoverse.palaeoverse.org/articles/structure-and-standards.html)
- [x] I have performed a self-review of my code.
- [ ] I have added function documentation.
- [ ] I have provided sufficient examples of implementation.
- [ ] If it is a core feature, I have added thorough tests.

