### PR TITLE
Fix `look_up()` with wrong input

### DIFF
--- a/R/look_up.R
+++ b/R/look_up.R
@@ -149,7 +149,7 @@ look_up <- function(
 
   # int_key checks
   if (!is.data.frame(int_key)) {
-    if (int_key) {
+    if (!isFALSE(int_key)) {
       stop("`int_key` should be a dataframe.")
     } else {
       if (!(assign_with_GTS %in% c("GTS2020", "GTS2012"))) {


### PR DESCRIPTION
I was too quick to merge #169  after integrating changes from #173  in it. One of the changes in #169 (changing `int_key != FALSE` to `int_key`) changed the error message for one case, which was fine before because this was wrapped in `expect_error()`, but after #173 we were checking the error message in detail and therefore the snapshot test failed.

This PR fixes it (it doesn't need to appear in NEWS since the failure was caused a couple of commits ago).

---

Edit: to clarify, changing `int_key != FALSE` to `int_key` would have been fine if `int_key` could only be a logical value, but here it can be something else.

## Checklist before requesting a review
- [x] I have read palaeoverse's [standards and structure](https://palaeoverse.palaeoverse.org/articles/structure-and-standards.html)
- [x] I have performed a self-review of my code.
- [ ] I have added function documentation.
- [ ] I have provided sufficient examples of implementation.
- [ ] If it is a core feature, I have added thorough tests.

