### PR TITLE
Deactivate a few more `lintr` rules

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,8 +27,8 @@ jobs:
 
       - name: Lint
         run: |
-          # Air takes care of all formatting so we deactivate all formatting-related rules
           lintr::lint_package(linters = lintr::linters_with_defaults(
+            # Air takes care of all formatting so we deactivate all formatting-related rules
             absolute_path_linter = NULL,
             brace_linter = NULL,
             commas_linter = NULL,
@@ -37,12 +37,18 @@ jobs:
             infix_spaces_linter = NULL,
             line_length_linter = NULL,
             paren_body_linter = NULL,
+            pipe_continuation_linter = NULL,
             semicolon_linter = NULL,
             spaces_inside_linter = NULL,
             spaces_left_parentheses_linter = NULL,
             trailing_blank_lines_linter = NULL,
             trailing_whitespace_linter = NULL,
-            whitespace_linter = NULL
+            whitespace_linter = NULL,
+
+            # Handled by Jarl
+            equals_na_linter = NULL,
+            quotes_linter = NULL,
+            T_and_F_symbol_linter_linter = NULL
           ))
         shell: Rscript {0}
         env:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,7 +29,6 @@ jobs:
         run: |
           lintr::lint_package(linters = lintr::linters_with_defaults(
             # Air takes care of all formatting so we deactivate all formatting-related rules
-            absolute_path_linter = NULL,
             brace_linter = NULL,
             commas_linter = NULL,
             function_left_parentheses_linter = NULL,
@@ -48,7 +47,7 @@ jobs:
             # Handled by Jarl
             equals_na_linter = NULL,
             quotes_linter = NULL,
-            T_and_F_symbol_linter_linter = NULL
+            T_and_F_symbol_linter = NULL
           ))
         shell: Rscript {0}
         env:

--- a/R/bin_time.R
+++ b/R/bin_time.R
@@ -180,7 +180,7 @@ bin_time <- function(
   }
 
   if (method == "point" && !is.function(fun)) {
-    stop('`fun` is not a function.')
+    stop("`fun` is not a function.")
   }
 
   #=== Reporting Info ===

--- a/R/tax_range_strat.R
+++ b/R/tax_range_strat.R
@@ -138,11 +138,11 @@ tax_range_strat <- function(
   }
 
   if (length(group) > 1) {
-    stop('`group` length is >1, only a single grouping variable is accepted.')
+    stop("`group` length is >1, only a single grouping variable is accepted.")
   }
 
   if (!is.null(group) && !group %in% colnames(occdf)) {
-    stop('`group` is not a named column in `occdf`')
+    stop("`group` is not a named column in `occdf`")
   }
 
   if (!all(c(name, level) %in% colnames(occdf))) {

--- a/R/tax_range_time.R
+++ b/R/tax_range_time.R
@@ -136,11 +136,11 @@ tax_range_time <- function(
   }
 
   if (length(group) > 1) {
-    stop('`group` length is >1, only a single grouping variable is accepted.')
+    stop("`group` length is >1, only a single grouping variable is accepted.")
   }
 
   if (!is.null(group) && (!group %in% colnames(occdf))) {
-    stop('`group` is not a named column in `occdf`')
+    stop("`group` is not a named column in `occdf`")
   }
 
   if (!by %in% c("name", "FAD", "LAD")) {

--- a/jarl.toml
+++ b/jarl.toml
@@ -1,6 +1,6 @@
 [lint]
 # Use the default set of rules + the testthat-specific rules
-extend-select = ["TESTTHAT"]
+extend-select = ["quotes", "TESTTHAT"]
 ignore = ["expect_type"]
 fixable = ["ALL"]
 fix-roxygen = true
@@ -9,3 +9,6 @@ fix-roxygen = true
 # https://github.com/r-lib/tree-sitter-r/issues/189
 # [lint.assignment]
 # operator = "<-"
+
+[lint.quotes]
+quote = "double"

--- a/jarl.toml
+++ b/jarl.toml
@@ -1,5 +1,4 @@
 [lint]
-# Use the default set of rules + the testthat-specific rules
 extend-select = ["quotes", "TESTTHAT"]
 ignore = ["expect_type"]
 fixable = ["ALL"]

--- a/vignettes/source/_tetrapod-biodiversity.Rmd
+++ b/vignettes/source/_tetrapod-biodiversity.Rmd
@@ -123,7 +123,7 @@ colnames(tetrapods)[c(35, 37)] <- c("max_ma", "min_ma")
 # Generate time bins
 tetrapods <- bin_time(occdf = tetrapods,
                       bins = bins,
-                      method = 'mid')
+                      method = "mid")
 
 ```
 
@@ -136,7 +136,7 @@ cp_tetrapods <- subset(tetrapods, min_ma > min(bins$min_ma))
 # Bin occurrences into chosen time bins
 mid_tetrapods <- bin_time(occdf = cp_tetrapods,
                           bins = bins,
-                          method = 'mid')
+                          method = "mid")
 
 ```
 
@@ -163,7 +163,7 @@ As you can see, only ~25% of the dataset can be assigned to just one bin - the o
 # Bin occurrences into chosen time bins
 maj_tetrapods <- bin_time(occdf = cp_tetrapods,
                           bins = bins,
-                          method = 'majority')
+                          method = "majority")
 
 ```
 
@@ -189,8 +189,8 @@ Looks good to me! Now that we have palaeocoordinates for our occurrences, we can
 ```{r}
 # Make a table of potential number of bins
 maj_tetrapods <- bin_space(occdf = maj_tetrapods,
-                           lng = 'p_lng',
-                           lat = 'p_lat',
+                           lng = "p_lng",
+                           lat = "p_lat",
                            spacing = 100)
 
 # Show the first 6 rows of the new columns added using `bin_space`.


### PR DESCRIPTION
I deactivate a few more `lintr` rules (from [this comment](https://github.com/palaeoverse/palaeoverse/pull/179#issuecomment-4489295582)) that are already covered by Jarl and one that I had forgot that is covered by Air. I also applied fixes to use double quotes everywhere.

Remaining rules:

* assignment_linter (covered in the next version of Jarl)
* commented_code_linter
* object_length_linter
* object_name_linter
* object_usage_linter (probably covered in the next version of Jarl)
* pipe_consistency_linter (covered in the next version of Jarl)
* return_linter
* seq_linter (probably covered in the next version of Jarl)
* vector_logic_linter


## Checklist before requesting a review
- [x] I have read palaeoverse's [standards and structure](https://palaeoverse.palaeoverse.org/articles/structure-and-standards.html)
- [x] I have performed a self-review of my code.
- [ ] I have added function documentation.
- [ ] I have provided sufficient examples of implementation.
- [ ] If it is a core feature, I have added thorough tests.

