### PR TITLE
Test that `tax_range_time()` resets row names

### DIFF
--- a/tests/testthat/test-tax_range_time.R
+++ b/tests/testthat/test-tax_range_time.R
@@ -47,5 +47,5 @@ test_that("tax_range_time() resets row names", {
   tetrapods <- subset(tetrapods, !is.na(order) & order != "NO_ORDER_SPECIFIED")
   # Temporal range
   result <- tax_range_time(occdf = tetrapods, name = "order")
-  expect_equal(row.names(result), as.character(1:30))
+  expect_equal(row.names(result), as.character(seq_len(nrow(result))))
 })

--- a/tests/testthat/test-tax_range_time.R
+++ b/tests/testthat/test-tax_range_time.R
@@ -42,10 +42,10 @@ test_that("tax_range_time() works", {
   occdf$max_ma[1] <- "test"
   expect_snapshot(tax_range_time(occdf = occdf), error = TRUE)
 })
-test_that("tax_range_time()resets row names",{
+test_that("tax_range_time() resets row names", {
   # Remove NAs
   tetrapods <- subset(tetrapods, !is.na(order) & order != "NO_ORDER_SPECIFIED")
   # Temporal range
-  result<-tax_range_time(occdf = tetrapods, name = "order")
+  result <- tax_range_time(occdf = tetrapods, name = "order")
   expect_equal(row.names(result), as.character(1:30))
 })

--- a/tests/testthat/test-tax_range_time.R
+++ b/tests/testthat/test-tax_range_time.R
@@ -42,3 +42,10 @@ test_that("tax_range_time() works", {
   occdf$max_ma[1] <- "test"
   expect_snapshot(tax_range_time(occdf = occdf), error = TRUE)
 })
+test_that("tax_range_time()resets row names",{
+  # Remove NAs
+  tetrapods <- subset(tetrapods, !is.na(order) & order != "NO_ORDER_SPECIFIED")
+  # Temporal range
+  result<-tax_range_time(occdf = tetrapods, name = "order")
+  expect_equal(row.names(result), as.character(1:30))
+})


### PR DESCRIPTION
Add a test for #132
## Checklist before requesting a review
- [ ] I have read palaeoverse's [standards and structure](https://palaeoverse.palaeoverse.org/articles/structure-and-standards.html)
- [ ] I have performed a self-review of my code.
- [ ] I have added function documentation.
- [ ] I have provided sufficient examples of implementation.
- [ ] If it is a core feature, I have added thorough tests.

