### PR TITLE
Add cron job to run R CMD check once a week

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -5,6 +5,9 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+  schedule:
+    # Every Monday at 8am
+    - cron: "0 8 * * 1"
 
 name: R-CMD-check
 


### PR DESCRIPTION
This adds a cron job to run `R CMD check` once a week. This helps in the following scenario:

- initial situation: 
  - the latest stable version of `palaeoverse` works fine with package `FOO`
  - the development version of `palaeoverse` contains several new features that depend on package `FOO`
  - the development version of `palaeoverse` isn't actively worked on
- if package `FOO` is updated with large breaking changes, CRAN will only check that those changes don't affect the stable version of `palaeoverse`
- some breaking changes in `FOO` might affect the development version of `palaeoverse`

==> We need to run `R CMD check` periodically to capture changes in `FOO`, even if nothing changed in `palaeoverse`. We would discover those issues eventually when someone starts working again on `palaeoverse`, but this cron job simply makes us aware of those issues earlier.

Part of #165 

## Checklist before requesting a review
- [x] I have read palaeoverse's [standards and structure](https://palaeoverse.palaeoverse.org/articles/structure-and-standards.html)
- [x] I have performed a self-review of my code.
- [ ] I have added function documentation.
- [ ] I have provided sufficient examples of implementation.
- [ ] If it is a core feature, I have added thorough tests.

