### PR TITLE
Use specific commits for `R-CMD-check-hard`, update Codecov workflow, fix `check-description-citation` workflow

### DIFF
--- a/.github/workflows/R-CMD-check-hard.yaml
+++ b/.github/workflows/R-CMD-check-hard.yaml
@@ -26,18 +26,18 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-pandoc@9f58233a78a2a9fd874714be10f8bba627233339 # v2
         with:
           pandoc-version: "latest"
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@9f58233a78a2a9fd874714be10f8bba627233339 # v2
         with:
           r-version: "release"
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2
         with:
           dependencies: '"hard"'
           cache: false
@@ -49,7 +49,7 @@ jobs:
             any::knitr
             any::rmarkdown
 
-      - uses: r-lib/actions/check-r-package@v2
+      - uses: r-lib/actions/check-r-package@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2
         with:
           upload-snapshots: true
           build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/.github/workflows/check-description-citation-changes.yaml
+++ b/.github/workflows/check-description-citation-changes.yaml
@@ -79,13 +79,22 @@ jobs:
             if (!citationModified && !descriptionModified) {
               console.log('DESCRIPTION and CITATION.cff are both unmodified, skipping check.');
               // Remove label if it exists since both files are now unmodified
-              if (hasLabel) {
+              if (hasLabelDescription) {
                 console.log('Removing label');
                 await github.rest.issues.removeLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: prNumber,
-                  name: labelName,
+                  name: labelNameDescription,
+                });
+              }
+              if (hasLabelCitation) {
+                console.log('Removing label');
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  name: labelNameCitation,
                 });
               }
               return;

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -38,7 +38,7 @@ jobs:
           covr::to_cobertura(cov)
         shell: Rscript {0}
 
-      - uses: codecov/codecov-action@ca0a928a4cb3911011e868128a5cd90437c12db1 # v6
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           # Fail if error if not on PR, or if on PR and token is given
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This PR does three things:

- I forgot to use specific commits in the `R-CMD-check-hard` workflow (#182). This is now fixed.
- Codecov (used to test code coverage) has released v7 and we need to use it for the workflow to keep working: https://github.com/codecov/codecov-action/issues/1956
- the CI workflow added in #202 to check whether DESCRIPTION and/or CITATION.cff are modified had a logic error when both files are not modified. This is now fixed.

Supersedes #213 

Fixes #221 

## Checklist before requesting a review
- [x] I have read palaeoverse's [standards and structure](https://palaeoverse.palaeoverse.org/articles/structure-and-standards.html)
- [x] I have performed a self-review of my code.
- [ ] I have added function documentation.
- [ ] I have provided sufficient examples of implementation.
- [ ] If it is a core feature, I have added thorough tests.

