### PR TITLE
Update DOI badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![codecov](https://codecov.io/gh/palaeoverse/palaeoverse/branch/main/graph/badge.svg?token=HQQO2CRIKT)](https://app.codecov.io/gh/palaeoverse/palaeoverse)
 [![CRAN status](https://www.r-pkg.org/badges/version/palaeoverse)](https://CRAN.R-project.org/package=palaeoverse)
 [![CRAN downloads](https://cranlogs.r-pkg.org/badges/grand-total/palaeoverse)](https://cran.r-project.org/package=palaeoverse)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.13929873.svg)](https://doi.org/10.5281/zenodo.13929873)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7728638.svg)](https://doi.org/10.5281/zenodo.7728638)
 [![Bluesky URL](https://img.shields.io/badge/Bluesky-0285FF?logo=bluesky&logoColor=fff&label=Follow%20%40palaeoverse)](https://bsky.app/profile/palaeoverse.bsky.social)
 [![LinkedIn](https://custom-icon-badges.demolab.com/badge/LinkedIn-0A66C2?logo=linkedin-white&logoColor=fff&label=Follow%20%40Palaeoverse)](https://linkedin.com/company/palaeoverse)
 [![Contributors](https://img.shields.io/github/contributors/palaeoverse/palaeoverse)](https://github.com/palaeoverse/palaeoverse/graphs/contributors)


### PR DESCRIPTION
Currently, our README Zenodo badge links to a specific release of palaeoverse (1.4.0). It should instead use the 'collective' DOI link. This PR addresses that. 

Fixes #229.